### PR TITLE
Feature/modal reposition

### DIFF
--- a/js/modules/modal_module.js
+++ b/js/modules/modal_module.js
@@ -1,6 +1,7 @@
 /*!
 Modal Module R1.8
 Copyright 2010-2017 Bryan Garaventa (WhatSock.com)
+Copyright 2018 Danny Allen (dannya.com) / Wonderscore Ltd (wonderscore.co.uk)
 Part of AccDC, a Cross-Browser JavaScript accessibility API, distributed under the terms of the Open Source Initiative OSI - MIT License
 */
 
@@ -95,11 +96,7 @@ Part of AccDC, a Cross-Browser JavaScript accessibility API, distributed under t
 						runAfter: function(dc){
 							if (!openModals.length){
 								$A.bind(window, 'resize.accmodal', function(ev){
-									if (openModals[openModals.length - 1].autoFix)
-										openModals[openModals.length - 1].applyFix();
-
-									else if (openModals[openModals.length - 1].autoPosition)
-										openModals[openModals.length - 1].setPosition();
+									dc.reposition();
 								});
 								$A.bind('body', 'focusin.accmodal', function(ev){
 									if (openModals[openModals.length - 1].tempFocus)
@@ -141,6 +138,20 @@ Part of AccDC, a Cross-Browser JavaScript accessibility API, distributed under t
 							$A.query('*', dc.containerDiv, function(i, o){
 								$A.unbind(o, '*');
 							});
+						},
+
+						reposition: function () {
+							if (!openModals.length) {
+								return false;
+							}
+
+							if (openModals[openModals.length - 1].autoFix)
+								openModals[openModals.length - 1].applyFix();
+
+							else if (openModals[openModals.length - 1].autoPosition)
+								openModals[openModals.length - 1].setPosition();
+
+							return true;
 						},
 
 						// Set a localized focusIn handler on the AccDC Object to control circular tabbing

--- a/js/modules/modal_module.js
+++ b/js/modules/modal_module.js
@@ -156,7 +156,7 @@ Part of AccDC, a Cross-Browser JavaScript accessibility API, distributed under t
 
 						// Set a localized focusIn handler on the AccDC Object to control circular tabbing
 						focusIn: function(ev, dc){
-// dc.tempFocus will bubble up to the body focusIn handler to verify if focus is still within the AccDC Object or not
+							// dc.tempFocus will bubble up to the body focusIn handler to verify if focus is still within the AccDC Object or not
 							dc.tempFocus = this;
 						},
 						tabOut: function(ev, dc){
@@ -172,8 +172,8 @@ Part of AccDC, a Cross-Browser JavaScript accessibility API, distributed under t
 							if (k == 27)
 								dc.close();
 						},
-// Set the className for the close link, must match the className for any other close links in the rendered content
-// AccDC Object close functionality is automatically configured
+						// Set the className for the close link, must match the className for any other close links in the rendered content
+						// AccDC Object close functionality is automatically configured
 						closeClassName: 'lbClose',
 						className: 'modal'
 						}, true);


### PR DESCRIPTION
Refactor out Modal reposition logic into its own function, which can be called externally using a reference to a "dc" instance object.

Use case for this is when the content is dynamically modified (insertion / deletion / explicit sizing change of internal elements) after the Modal has already set its own position. An explicit call to this function enables the Modal to then be in its correct central position relative to the viewport.